### PR TITLE
add rb2_real alt rb2 source (from dx)

### DIFF
--- a/base/index.json
+++ b/base/index.json
@@ -282,7 +282,7 @@
 			"type": "rb"
 		},
 		{
-			"ids": [ "rb2" ], 
+			"ids": [ "rb2", "rb2_real" ], 
 			"names": {
 				"en-US": "Rock Band 2"
 			},


### PR DESCRIPTION
in rock band games, customs generated from onyx to rb2 (say ch conversions) get the source set as "rb2".

This causes both rb2 songs, and custom songs to be sorted under rb2.

By changing real rb2 songs to use rb2_real, any customs will fallback to "custom songs" in rb3dx.

This change to opensource is for anyone using cons + rb3dx songs updates moving forward, to reflect this change in yarg