### PR TITLE
improving Fret Smasher recognition

### DIFF
--- a/extra/index.json
+++ b/extra/index.json
@@ -1295,7 +1295,7 @@
 			"type": "custom"
 		},
 		{
-			"ids": [ "fretsmasher" ],
+			"ids": [ "fretsmasher", "fret smasher" ],
 			"names": {
 				"en-US": "Fret Smasher"
 			},


### PR DESCRIPTION
Fret Smasher's current charts use `icon = fret smasher`, with a space in the name. While this breaks with current OpenSource naming convention, adding the space allows those charts to be recognized without alteration.