### PR TITLE
Make Encore and GITADORA be labeled as games instead of custom

### DIFF
--- a/extra/index.json
+++ b/extra/index.json
@@ -583,7 +583,7 @@
 				"en-US": "GITADORA"
 			},
 			"icon": "gd",
-			"type": "custom"
+			"type": "game"
 		},
 		{
 			"ids": [ "gf1" ],
@@ -1436,7 +1436,7 @@
 				"en-US": "Encore"
 			},
 			"icon": "encore",
-			"type": "custom"			
+			"type": "game"			
 		},
 		{
 		    "ids": [ "lanebreakers" ],


### PR DESCRIPTION
This was probably a oversight but Encore and GITADORA were listed as customs instead of games.

https://github.com/Encore-Developers/Encore