### PR TITLE
Beatles DLC additional id

### DIFF
--- a/base/index.json
+++ b/base/index.json
@@ -346,7 +346,7 @@
 			"type": "rb"
 		},
 		{
-			"ids": [ "tbrbdlc" ], 
+			"ids": [ "tbrbdlc", "beatles_dlc" ], 
 			"names": {
 				"en-US": "The Beatles: Rock Band DLC"
 			},


### PR DESCRIPTION
RB3DX uses `beatles_dlc`