### PR TITLE
Add colon to The Beatles: Rock Band

### DIFF
--- a/base/index.json
+++ b/base/index.json
@@ -340,7 +340,7 @@
 		{
 			"ids": [ "tbrb", "beatles" ], 
 			"names": {
-				"en-US": "The Beatles Rock Band"
+				"en-US": "The Beatles: Rock Band"
 			},
 			"icon": "tbrb",
 			"type": "rb"


### PR DESCRIPTION
Change to match formatting of The Beatles: Rock Band DLC, Green Day: Rock Band, Pearl Jam: Rock Band.

Closes #111 